### PR TITLE
Fixes mysqli::real_escape_string(): Passing null to parameter 1 ($str…

### DIFF
--- a/upload/catalog/model/design/translation.php
+++ b/upload/catalog/model/design/translation.php
@@ -1,7 +1,7 @@
 <?php
 class ModelDesignTranslation extends Model {
 	public function getTranslations($route) {
-		$language_code = !empty($this->session->data['language']) ? $this->session->data['language'] : $this->config->get('config_language');
+		$language_code = !empty($this->session->data['language']) ? $this->session->data['language'] : (string)$this->config->get('config_language');
 		
 		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "translation` WHERE `store_id` = '" . (int)$this->config->get('config_store_id') . "' AND `language_id` = '" . (int)$this->config->get('config_language_id') . "' AND (`route` = '" . $this->db->escape($route) . "' OR `route` = '" . $this->db->escape($language_code) . "')");
 


### PR DESCRIPTION
…ing) of type string is deprecated.

$language_code = !empty($this->session->data['language']) ? $this->session->data['language'] : (string)$this->config->get('config_language');