### PR TITLE
Fixed non mail->send must return bool

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -139,6 +139,6 @@ class Mail {
 			$this->adaptor->$key = $value;
 		}
 		
-		$this->adaptor->send();
+		return $this->adaptor->send();
 	}
 }


### PR DESCRIPTION
This fixes an issue with all mail adapaters because the mail->send function is expected to return a bool.