### PR TITLE
Fixed missing customer_token

### DIFF
--- a/upload/catalog/controller/account/affiliate.php
+++ b/upload/catalog/controller/account/affiliate.php
@@ -115,7 +115,7 @@ class ControllerAccountAffiliate extends Controller {
 			$data['error_custom_field'] = array();
 		}
 				
-		$data['action'] = $this->url->link($this->request->get['route'], '', true);
+		$data['action'] = $this->url->link($this->request->get['route'], 'customer_token=' . $this->session->data['customer_token'], true);
 		
 		if ($this->request->get['route'] == 'account/affiliate/edit' && $this->request->server['REQUEST_METHOD'] != 'POST') {
 			$affiliate_info = $this->model_account_customer->getAffiliate($this->customer->getId());

--- a/upload/catalog/controller/affiliate/register.php
+++ b/upload/catalog/controller/affiliate/register.php
@@ -122,7 +122,7 @@ class ControllerAffiliateRegister extends Controller {
 			$data['error_bank_account_number'] = '';
 		}
 				
-		$data['action'] = $this->url->link('affiliate/register', '', true);
+		$data['action'] = $this->url->link('affiliate/register', 'customer_token=' . $this->session->data['customer_token'], true);
 
 		$data['customer_groups'] = array();
 


### PR DESCRIPTION
Fixes missing customer_token in both affiliate/register and account/affiliate.

Without the token it is not possible to save affiliate data.