### PR TITLE
Fix a void function must not return a value in tracking controller

### DIFF
--- a/upload/catalog/controller/account/tracking.php
+++ b/upload/catalog/controller/account/tracking.php
@@ -14,48 +14,49 @@ class ControllerAccountTracking extends Controller {
 		$this->load->model('account/customer');
 
 		$affiliate_info = $this->model_account_customer->getAffiliate($this->customer->getId());
-			
-		if ($affiliate_info) {
-			$this->load->language('account/tracking');
-	
-			$this->document->setTitle($this->language->get('heading_title'));
-	
-			$data['breadcrumbs'] = array();
-	
-			$data['breadcrumbs'][] = array(
-				'text' => $this->language->get('text_home'),
-				'href' => $this->url->link('common/home')
-			);
-	
-			$data['breadcrumbs'][] = array(
-				'text' => $this->language->get('text_account'),
-				'href' => $this->url->link('account/account', '', true)
-			);
-	
-			$data['breadcrumbs'][] = array(
-				'text' => $this->language->get('heading_title'),
-				'href' => $this->url->link('account/tracking', '', true)
-			);
-	
-			$data['text_description'] = sprintf($this->language->get('text_description'), $this->config->get('config_name'));
-	
-			$data['code'] = $affiliate_info['tracking'];
-	
-			$data['continue'] = $this->url->link('account/account', 'customer_token=' . $this->session->data['customer_token'], true);
-			
-			$data['customer_token'] = $this->session->data['customer_token'];
-	
-			$data['column_left'] = $this->load->controller('common/column_left');
-			$data['column_right'] = $this->load->controller('common/column_right');
-			$data['content_top'] = $this->load->controller('common/content_top');
-			$data['content_bottom'] = $this->load->controller('common/content_bottom');
-			$data['footer'] = $this->load->controller('common/footer');
-			$data['header'] = $this->load->controller('common/header');
-	
-			$this->response->setOutput($this->load->view('account/tracking', $data));
-		} else {
-			return new \Action('error/not_found');
+		
+		if (!$affiliate_info) {
+			$this->response->redirect($this->url->link('account/account', 'language=' . $this->config->get('config_language') . '&customer_token=' . $this->session->data['customer_token']));
 		}
+		
+		$this->load->language('account/tracking');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$data['breadcrumbs'] = array();
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/home')
+		);
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_account'),
+			'href' => $this->url->link('account/account', '', true)
+		);
+
+		$data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('account/tracking', '', true)
+		);
+
+		$data['text_description'] = sprintf($this->language->get('text_description'), $this->config->get('config_name'));
+
+		$data['code'] = $affiliate_info['tracking'];
+
+		$data['continue'] = $this->url->link('account/account', 'customer_token=' . $this->session->data['customer_token'], true);
+		
+		$data['customer_token'] = $this->session->data['customer_token'];
+
+		$data['column_left'] = $this->load->controller('common/column_left');
+		$data['column_right'] = $this->load->controller('common/column_right');
+		$data['content_top'] = $this->load->controller('common/content_top');
+		$data['content_bottom'] = $this->load->controller('common/content_bottom');
+		$data['footer'] = $this->load->controller('common/footer');
+		$data['header'] = $this->load->controller('common/header');
+
+		$this->response->setOutput($this->load->view('account/tracking', $data));
+	
 	}
 
 	public function autocomplete(): void {


### PR DESCRIPTION
This pull request fixes:
A void function must not return a value catalog/controller/account/tracking.php Line 57

Otherwise the tracking page for affiliate cannot be entered by the customer.  What we are doing now is redirecting the user to account/account instead of not_found reply when the customer affiliate has been deleted within the admin panel.