### PR TITLE
Fix sorting of custom fields

### DIFF
--- a/upload/admin/view/template/sale/order_form.twig
+++ b/upload/admin/view/template/sale/order_form.twig
@@ -2306,11 +2306,11 @@
   <script type="text/javascript"><!--
       // Sort the custom fields
       $('#tab-customer .form-group[data-sort]').detach().each(function () {
-          if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#tab-customer .form-group').length) {
+          if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') < $('#tab-customer .form-group').length) {
               $('#tab-customer .form-group').eq($(this).attr('data-sort')).before(this);
           }
 
-          if ($(this).attr('data-sort') > $('#tab-customer .form-group').length) {
+          if ($(this).attr('data-sort') >= $('#tab-customer .form-group').length) {
               $('#tab-customer .form-group:last').after(this);
           }
 
@@ -2321,11 +2321,11 @@
 
       // Sort the custom fields
       $('#tab-payment .form-group[data-sort]').detach().each(function () {
-          if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#tab-payment .form-group').length) {
+          if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') < $('#tab-payment .form-group').length) {
               $('#tab-payment .form-group').eq($(this).attr('data-sort')).before(this);
           }
 
-          if ($(this).attr('data-sort') > $('#tab-payment .form-group').length) {
+          if ($(this).attr('data-sort') >= $('#tab-payment .form-group').length) {
               $('#tab-payment .form-group:last').after(this);
           }
 
@@ -2335,11 +2335,11 @@
       });
 
       $('#tab-shipping .form-group[data-sort]').detach().each(function () {
-          if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') <= $('#tab-shipping .form-group').length) {
+          if ($(this).attr('data-sort') >= 0 && $(this).attr('data-sort') < $('#tab-shipping .form-group').length) {
               $('#tab-shipping .form-group').eq($(this).attr('data-sort')).before(this);
           }
 
-          if ($(this).attr('data-sort') > $('#tab-shipping .form-group').length) {
+          if ($(this).attr('data-sort') >= $('#tab-shipping .form-group').length) {
               $('#tab-shipping .form-group:last').after(this);
           }
 


### PR DESCRIPTION
This commit fixes the issue of custom fields not being displayed if the sort order(+3) of the custom field is the same as the total length of all the fields. If the custom field that is not displayed is required, it prevents users to go to the next step.


E.g.

There are 8 fields in the form and there is a custom field with sort order of 5. Sort orders are increased by 3 on this form so the first if evaluates to true but there isn't an 8th index for $('#tab-customer .form-group'). Therefore $('#tab-customer .form-group').eq(8) doesn't work.