### PR TITLE
Removes the depricated parameter from the error handler's callee

### DIFF
--- a/upload/install/cli_install.php
+++ b/upload/install/cli_install.php
@@ -45,7 +45,7 @@ $registry = new \Registry();
 $loader = new \Loader($registry);
 $registry->set('load', $loader);
 
-function handleError($errno, $errstr, $errfile, $errline, array $errcontext) {
+function handleError($errno, $errstr, $errfile, $errline) {
     // error was suppressed with the @-operator
     if (!(error_reporting() & $errno)) {
         return false;


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function handleError(), 4 passed in /home/jigius/work/sandbox/opencart-3/upload/install/cli_install.php on line 365 and exactly 5 expected in /home/jigius/work/sandbox/opencart-3/upload/install/cli_install.php:48
```
Fixes the issue - removes the [depricated and later removed](https://www.php.net/manual/en/function.set-error-handler.php) 5th parameter  from the error handler's callee.