### PR TITLE
Added missing whitespace between both buttons

### DIFF
--- a/upload/admin/view/template/extension/extension/module.twig
+++ b/upload/admin/view/template/extension/extension/module.twig
@@ -48,7 +48,7 @@
               <tr>
                 <td class="text-left">&nbsp;&nbsp;&nbsp;<i class="fa fa-folder-open"></i>&nbsp;&nbsp;&nbsp;{{ module.name }}</td>
                 <td class="text-left">{{ module.status }}</td>
-                <td class="text-right"><a href="{{ module.edit }}" data-toggle="tooltip" title="{{ button_edit }}" class="btn btn-info"><i class="fa fa-pencil"></i></a><a href="{{ module.delete }}" data-toggle="tooltip" title="{{ button_delete }}" class="btn btn-warning"><i class="fa fa-trash-o"></i></a></td>
+                <td class="text-right"><a href="{{ module.edit }}" data-toggle="tooltip" title="{{ button_edit }}" class="btn btn-info"><i class="fa fa-pencil"></i></a>&nbsp;<a href="{{ module.delete }}" data-toggle="tooltip" title="{{ button_delete }}" class="btn btn-warning"><i class="fa fa-trash-o"></i></a></td>
               </tr>
             {% endfor %}
           {% endfor %}


### PR DESCRIPTION
Added a missing whitespace to seperate all buttons correctly.

![grafik](https://github.com/opencart/opencart-3/assets/32510006/f9238e13-22bb-40c4-b32d-53b83a738b13)
