### PR TITLE
Fix moving files from ocmods not working

### DIFF
--- a/upload/admin/controller/marketplace/install.php
+++ b/upload/admin/controller/marketplace/install.php
@@ -106,7 +106,7 @@ class ControllerMarketplaceInstall extends Controller {
                 $files = [];
 
                 // Get a list of files ready to upload
-                $path = [$directory . 'upload/*'];
+                $path = [$directory . 'upload/'];
 
                 while (count($path) != 0) {
                     $next = array_shift($path);
@@ -114,7 +114,7 @@ class ControllerMarketplaceInstall extends Controller {
                     if (is_dir($next)) {
                         foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
                             if (is_dir($file)) {
-                                $path[] = $file . '/*';
+                                $path[] = $file . '/';
                             }
 
                             $files[] = $file;


### PR DESCRIPTION
This PR removes the `*` from both the `$path` and `$path[]` assignment.  Otherwise
`if (is_dir($next)) {` will return false because `*` is not a directory.

This fixes all missing files from the `upload` folder from every ocmod installation.

Fixes #169 