### PR TITLE
Fix storage folder not moving correctly

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -80,7 +80,7 @@ class ControllerCommonSecurity extends Controller {
                         foreach (glob(trim($next, '/') . '/{*,.[!.]*,..?*}', GLOB_BRACE) as $file) {
                             // If directory add to path array
                             if (is_dir($file)) {
-                                $source[] = $file . '/*';
+                                $source[] = $file . '/';
                             }
 
                             // Add the file to the files to be deleted array
@@ -96,7 +96,7 @@ class ControllerCommonSecurity extends Controller {
 
                 // Copy the
                 foreach ($files as $file) {
-                    $destination = $path . $directory . substr($file, strlen(DIR_SYSTEM . 'storage/'));
+                    $destination = $path . $directory . substr($file, strlen(DIR_SYSTEM . 'storage/') - 1);
 
                     if (is_dir($file) && !is_dir($destination)) {
                         mkdir($destination, 0777);


### PR DESCRIPTION
This PR fixes #168

The `/` was cut-off which resulted in all folders within the `system/storage` folder being created seperately in the root folder of the move dialog. 

In addition I've removed the `*` from the `$source[]` since it won'T recognize the files otherwise.