### PR TITLE
Added  array to fix Warning Creation of dynamic property in PHP 8.2.

### DIFF
--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -11,11 +11,12 @@
  * Proxy class
  */
 class Proxy {
+	protected array $data = [];
     /**
      * @param    string    $key
      */
     public function __get($key) {
-        return $this->{$key};
+        return $this->data[$key];
     }
 
     /**
@@ -23,7 +24,7 @@ class Proxy {
      * @param    string    $value
      */
     public function __set($key, $value) {
-        $this->{$key} = $value;
+        $this->data[$key] = $value;
     }
 
     public function __call($key, $args) {
@@ -39,8 +40,8 @@ class Proxy {
             }
         }
 
-        if (isset($this->{$key})) {
-            return call_user_func_array($this->{$key}, $arg_data);
+        if (isset($this->data[$key])) {
+            return call_user_func_array($this->data[$key], $arg_data);
         } else {
             $trace = debug_backtrace();
 

--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -5,6 +5,7 @@ final class Twig {
     protected string $directory = '';
     protected object $loader;
     protected array  $path      = [];
+	protected array  $data      = [];
 
     public function set(string $key, mixed $value): void {
         $this->data[$key] = $value;


### PR DESCRIPTION
This commit adds an array `$data` to both `upload/system/engine/proxy.php` and `upload/system/library/template/twig.php` in order to be compatible with PHP 8.2. [Dynamic properties will throw a fatal error in PHP 9. ](https://php.watch/versions/8.2/dynamic-properties-deprecated)

Without this change the the store is not fully working on PHP 8.2.

Frontend:
![image](https://github.com/opencart/opencart-3/assets/32510006/d6552571-c69a-488b-a1c3-0015261064b2)

Backend:
![image](https://github.com/opencart/opencart-3/assets/32510006/3a1cc817-9954-4bc7-b8c2-dec358a127bd)



Fixes #176 