### PR TITLE
Remove adding recurring descriptions when new language is being added

### DIFF
--- a/upload/admin/model/localisation/language.php
+++ b/upload/admin/model/localisation/language.php
@@ -189,12 +189,7 @@ class ModelLocalisationLanguage extends Model {
 
         $this->cache->delete('weight_class');
 
-        // Profiles
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "recurring_description` WHERE `language_id` = '" . (int)$this->config->get('config_language_id') . "'");
-
-        foreach ($query->rows as $recurring) {
-            $this->db->query("INSERT INTO `" . DB_PREFIX . "recurring_description` SET `recurring_id` = '" . (int)$recurring['recurring_id'] . "', `language_id` = '" . (int)$language_id . "', `name` = '" . $this->db->escape($recurring['name']) . "'");
-        }
+       
 
         return $language_id;
     }


### PR DESCRIPTION
When adding a new language within the the route `admin/index.php?route=localisation/language/add`

the save method tries to copy all current translations for the current language for the new language. This process tries to insert into the table `recurring_description` which doesn't exist anymore.

@TheCartpenter you might want to add copying the translations for both `subscription_plan_description` and `subscription_status` here as well. I wasn't sure about caching so I didn't add those there yet.