### PR TITLE
Create missing Ref definition

### DIFF
--- a/upload/system/engine/ref.php
+++ b/upload/system/engine/ref.php
@@ -1,0 +1,5 @@
+<?php
+
+interface Ref {
+    public function getRef();
+}


### PR DESCRIPTION
With out this the check in system/engine/proxy.php will always fail, but since it appears you want to keep it the only other solution is to create the symbol.