### PR TITLE
Disable Event extension

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2, cs2pr
-                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml
+                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom
 
             - name: Lint
               run: |

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2, cs2pr
-                  extensions: none, bcmath, curl, hash, json, openssl, xml
+                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml
 
             - name: Lint
               run: |

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2, cs2pr
-                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom, simplexml
+                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom, simplexml, xmlwriter
 
             - name: Lint
               run: |

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2, cs2pr
-                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom
+                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom, simplexml
 
             - name: Lint
               run: |

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -26,6 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2, cs2pr
+                  extensions: none, bcmath, curl, hash, json, openssl, xml
 
             - name: Lint
               run: |

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2, cs2pr
-                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom, simplexml, xmlwriter
+                  extensions: none, mbstring, bcmath, curl, hash, json, openssl, xml, dom, simplexml, xmlwriter, tokenizer
 
             - name: Lint
               run: |


### PR DESCRIPTION
OC3 is incompatible with servers with the https://www.php.net/manual/en/book.event.php extension installed since it clashes with the OC Event model with is created in the root namespace rather then having it's own.

This disables the extension to allow tests to pass. See https://github.com/shivammathur/setup-php#heavy_plus_sign-php-extension-support