### PR TITLE
Disable use of PHP 8's Dynamic Constants

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -53,6 +53,7 @@ return $config
         'function_to_constant' => true,
         'general_phpdoc_annotation_remove' => true,
         'general_phpdoc_tag_rename' => true,
+        'get_class_to_class_keyword' => false,
         'heredoc_indentation' => true,
         'heredoc_to_nowdoc' => true,
         'implode_call' => true,


### PR DESCRIPTION
It appears that there is a misunderstanding of what `::class` is, where some think it's a static function. This is not the case it is a Dynamic Constant and is well with in Object Oriented Programming style. In fact the use of `get_class()` is Procedural Functional Programming which is not OOP.

For additional context please see: https://wiki.php.net/rfc/class_name_literal_on_object

All in all I'm against the change in this PR since it supports an in correct assumption about what OOP is or isn't, but it would allow the test to pass so if the maintainers are unwilling to change there stance then this is the next best solution. The proper solution would be to revert https://github.com/opencart/opencart-3/commit/9527e2b628ef8ed7a16272f665eedd2729271cde