### PR TITLE
Add sumbol discoverty for magic properties for PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
 		"cardinity/cardinity-sdk-php": "^3.2",
 		"scssphp/scssphp": "^1.12",
 		"zoujingli/wechat-developer": "^1.2"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tools\\PHPStan\\": "tools/phpstan/"
+        }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,10 @@
+services:
+	-
+		class: \Tools\PHPStan\RegistryPropertyReflectionExtension
+		tags:
+			- phpstan.broker.propertiesClassReflectionExtension
 parameters:
-	level: 0
+	level: 1
 	paths:
 		- ./upload/
 	excludePaths:
@@ -25,8 +30,8 @@ parameters:
 		- ./upload/catalog/model/extension/payment/wechat_pay.php
 		- ./system/library/googleshopping/
 		- ./upload/system/library/googleshopping/
-		- ./system/storage/vendor/
 		- ./upload/system/storage/vendor/
 	tmpDir: .cache
 	ignoreErrors:
 		- '#Class Event constructor invoked with 1 parameter, 4-5 required\.#'
+		- '#Constant [A-Z_]+ not found\.#'

--- a/tools/phpstan/LoadedProperty.php
+++ b/tools/phpstan/LoadedProperty.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tools\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+
+class LoadedProperty implements PropertyReflection {
+	/**
+	 * @var ClassReflection
+	 */
+	private $declaringClass;
+	/**
+	 * @var Type
+	 */
+	private $type;
+
+	public function __construct(ClassReflection $declaringClass, Type $readableType) {
+		$this->declaringClass = $declaringClass;
+		$this->type = $readableType;
+	}
+
+	public function getDeclaringClass(): ClassReflection {
+		return $this->declaringClass;
+	}
+
+	public function isStatic(): bool {
+		return false;
+	}
+
+	public function isPrivate(): bool {
+		return false;
+	}
+
+	public function isPublic(): bool {
+		return true;
+	}
+
+	public function isReadable(): bool {
+		return true;
+	}
+
+	public function isWritable(): bool {
+		return false;
+	}
+
+	public function getDocComment(): ?string {
+		return null;
+	}
+
+	public function getReadableType(): Type {
+		return $this->type;
+	}
+
+	public function getWritableType(): Type {
+		return new NeverType();
+	}
+
+	public function canChangeTypeAfterAssignment(): bool {
+		return false;
+	}
+
+	public function isDeprecated(): TrinaryLogic {
+		return TrinaryLogic::createNo();
+	}
+
+	public function getDeprecatedDescription(): ?string {
+		return null;
+	}
+
+	public function isInternal(): TrinaryLogic {
+		return TrinaryLogic::createNo();
+	}
+}

--- a/tools/phpstan/RegistryPropertyReflectionExtension.php
+++ b/tools/phpstan/RegistryPropertyReflectionExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tools\PHPStan;
+
+use Registry;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+
+class RegistryPropertyReflectionExtension implements PropertiesClassReflectionExtension {
+	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool {
+		if (!$classReflection->is(Registry::class)) {
+			return false;
+		}
+
+		return preg_match('/^model_.+$/', $propertyName, $matches) === 1;
+	}
+
+	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection {
+		preg_match('/^(model_.+)$/', $propertyName, $matches);
+		$className = $this->convertSnakeToStudly($matches[1]);
+
+		$broker = Broker::getInstance();
+
+		$type = new NullType();
+		if ($broker->hasClass($className)) {
+			$found = new ObjectType($className);
+			$type = new GenericObjectType('\Proxy', [$found]);
+			$type = TypeCombinator::addNull($type);
+		}
+
+		return new LoadedProperty($classReflection, $type);
+	}
+
+	private function convertSnakeToStudly(string $value): string {
+		return str_replace(' ', '', ucwords(str_replace('_', ' ', $value)));
+	}
+}

--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -11,6 +11,8 @@
 
 /**
  * Controller class
+ *
+ * @mixin Registry
  */
 class Controller {
 	protected object $registry;

--- a/upload/system/engine/model.php
+++ b/upload/system/engine/model.php
@@ -11,6 +11,8 @@
 
 /**
  * Model class
+ *
+ * @mixin Registry
  */
 abstract class Model {
 	protected object $registry;

--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -11,6 +11,10 @@
 
 /**
  * Proxy class
+ *
+ * @template TWraps of Model
+ *
+ * @mixin TWraps
  */
 class Proxy {
 	protected array $data = [];

--- a/upload/system/engine/registry.php
+++ b/upload/system/engine/registry.php
@@ -11,9 +11,44 @@
 
 /**
  * Registry class
+ *
+ * @property Cache                         $cache
+ * @property Cart\Cart                     $cart
+ * @property Cart\Currency                 $currency
+ * @property Cart\Customer                 $customer
+ * @property Cart\Length                   $length
+ * @property Cart\Tax                      $tax
+ * @property ?Cart\User                    $user
+ * @property Cart\Weight                   $weight
+ * @property Config                        $config
+ * @property Config                        $setting
+ * @property DB                            $db
+ * @property Document                      $document
+ * @property Event                         $event
+ * @property googleshopping\Googleshopping $googleshopping
+ * @property Language                      $language
+ * @property Loader                        $load
+ * @property Log                           $log
+ * @property Request                       $request
+ * @property Response                      $response
+ * @property Session                       $session
+ * @property Url                           $url
  */
 class Registry {
 	private array $data = [];
+
+	/**
+	 * __get
+	 *
+	 * https://www.php.net/manual/en/language.oop5.overloading.php#object.get
+	 *
+	 * @param string $key
+	 *
+	 * @return ?object
+	 */
+	public function __get(string $key): ?object {
+		return $this->get($key);
+	}
 
 	/**
 	 * @param string $key

--- a/upload/system/storage/vendor/composer/autoload_psr4.php
+++ b/upload/system/storage/vendor/composer/autoload_psr4.php
@@ -11,6 +11,7 @@ return array(
     'WeMini\\' => array($vendorDir . '/zoujingli/wechat-developer/WeMini'),
     'WeChat\\' => array($vendorDir . '/zoujingli/wechat-developer/WeChat'),
     'Twig\\' => array($vendorDir . '/twig/twig/src'),
+    'Tools\\PHPStan\\' => array($baseDir . '/tools/phpstan'),
     'Symfony\\Polyfill\\Php81\\' => array($vendorDir . '/symfony/polyfill-php81'),
     'Symfony\\Polyfill\\Php80\\' => array($vendorDir . '/symfony/polyfill-php80'),
     'Symfony\\Polyfill\\Php73\\' => array($vendorDir . '/symfony/polyfill-php73'),

--- a/upload/system/storage/vendor/composer/autoload_static.php
+++ b/upload/system/storage/vendor/composer/autoload_static.php
@@ -28,6 +28,7 @@ class ComposerStaticInit723df5bcd9366cc0d09a11e95c1b3994
         'T' => 
         array (
             'Twig\\' => 5,
+            'Tools\\PHPStan\\' => 14,
         ),
         'S' => 
         array (
@@ -86,6 +87,10 @@ class ComposerStaticInit723df5bcd9366cc0d09a11e95c1b3994
         'Twig\\' => 
         array (
             0 => __DIR__ . '/..' . '/twig/twig/src',
+        ),
+        'Tools\\PHPStan\\' => 
+        array (
+            0 => __DIR__ . '/../../../../..' . '/tools/phpstan',
         ),
         'Symfony\\Polyfill\\Php81\\' => 
         array (


### PR DESCRIPTION
Document enough of OC's object relation that PHPStan can produce sensible results for level 1.

@TheCartpenter If you can resolve all the issues that it is now able to find on level 1, then maybe you can make PRs for OC4 and when they are all fixed then `- '#^Variable \$\S+ might not be defined\.$#'` can be removed. Good luck.