### PR TITLE
Create missing $data property in language.php

### DIFF
--- a/upload/catalog/model/localisation/language.php
+++ b/upload/catalog/model/localisation/language.php
@@ -5,6 +5,8 @@
  * @package Catalog\Model\Localisation
  */
 class ModelLocalisationLanguage extends Model {
+	private array $data = [];
+
 	/**
 	 * getLanguage
 	 *


### PR DESCRIPTION
This should address the following errors:

```
  Line   catalog/model/localisation/language.php                       
 ------ -------------------------------------------------------------- 
  30     Access to private property ModelLocalisationLanguage::$data.  
  49     Access to private property ModelLocalisationLanguage::$data.  
```

The issue here looks to be that the property is missing and it's then falling through to the Registry which has a private property by the same name which would not be directly accessible from ModelLocalisationLanguage. PHP would then create a local property on the fly.