### PR TITLE
Assert Autoloader

### DIFF
--- a/upload/system/engine/registry.php
+++ b/upload/system/engine/registry.php
@@ -12,6 +12,7 @@
 /**
  * Registry class
  *
+ * @property Autoloader                    $autoloader
  * @property Cache                         $cache
  * @property Cart\Cart                     $cart
  * @property Cart\Currency                 $currency

--- a/upload/system/framework.php
+++ b/upload/system/framework.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * Loaded in an outside context
+ * @var Autoloader $autoloader
+ */
+
 // Registry
 $registry = new \Registry();
 $registry->set('autoloader', $autoloader);

--- a/upload/system/vendor.php
+++ b/upload/system/vendor.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * Loaded in an outside context
+ * @var Autoloader $autoloader
+ */
+
 // guzzlehttp/guzzle
 $autoloader->register('GuzzleHttp', DIR_STORAGE . 'vendor/guzzlehttp/guzzle/src/', true);
 


### PR DESCRIPTION
This file must be loaded in a context that already has a $autoloader variable, since we can't know that for sure the only option short of rewriting the start up process is to either assert it's existence with PHPDoc or ignore it.