### PR TITLE
Typo config library

### DIFF
--- a/upload/system/library/config.php
+++ b/upload/system/library/config.php
@@ -30,11 +30,11 @@ class Config {
 	 * Set
 	 *
 	 * @param string $key
-	 * @param int    $value
+	 * @param string $value
 	 *
 	 * @return void
 	 */
-	public function set(string $key, int $value): void {
+	public function set(string $key, string $value): void {
 		$this->data[$key] = $value;
 	}
 


### PR DESCRIPTION
With int used, you get this error:

Uncaught TypeError: Config::set():

Argument #2 ($value) must be of type int, string given, called in catalog\controller\startup\setting.php on line 31 and defined in system\library\config.php:37