### PR TITLE
Update excanvas.js DOM text reinterpreted as HTML

### DIFF
--- a/upload/admin/view/javascript/jquery/flot/excanvas.js
+++ b/upload/admin/view/javascript/jquery/flot/excanvas.js
@@ -1320,7 +1320,7 @@ if (!document.createElement('canvas').getContext) {
       this.textMeasureEl_ = this.element_.lastChild;
     }
     var doc = this.element_.ownerDocument;
-    this.textMeasureEl_.innerHTML = '';
+    this.textMeasureEl_.innerText = '';
     this.textMeasureEl_.style.font = this.font;
     // Don't use innerHTML or innerText because they allow markup/whitespace.
     this.textMeasureEl_.appendChild(doc.createTextNode(text));


### PR DESCRIPTION
Description:
`innerText` Would Be More Safer to use
By using `innerText`, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.