### PR TITLE
[3.0.4.0] Bug: popover appear empty

### DIFF
--- a/upload/admin/view/javascript/common.js
+++ b/upload/admin/view/javascript/common.js
@@ -114,6 +114,13 @@ $(document).ready(function() {
 
 		$element.popover('show');
 
+    // append buttons if popover appear empty
+    let popoverContent = $(".popover.fade.right.in .popover-content");
+    
+    if ( popoverContent.html() == ' ') {
+      popoverContent.append('<button type="button" id="button-image" class="btn btn-primary"><i class="fa fa-pencil"></i></button> <button type="button" id="button-clear" class="btn btn-danger"><i class="fa fa-trash-o"></i></button>')
+    }
+ 
 		$('#button-image').on('click', function() {
 			var $button = $(this);
 			var $icon   = $button.find('> i');


### PR DESCRIPTION
Bug: Popover appear empty on update images on admin dashboard
![2025-05-07_18-33](https://github.com/user-attachments/assets/950af7fb-40ca-4de4-a1e4-6a0886c2f62d)

Solved by: 
Checking if the popover content is empty, append buttons using jQuery after show the empty popover show buttons to update and delete images in admin dashbaord.